### PR TITLE
Add Spotify integration to version 3

### DIFF
--- a/src/jukebox/components/misc.py
+++ b/src/jukebox/components/misc.py
@@ -9,6 +9,7 @@ import jukebox.plugs as plugin
 import jukebox.utils
 from jukebox.daemon import get_jukebox_daemon
 import jukebox.cfghandler
+import jukebox.components.spotify
 
 logger = logging.getLogger('jb.misc')
 cfg = jukebox.cfghandler.get_handler('jukebox')
@@ -124,3 +125,21 @@ def set_app_settings(settings={}):
     """Set configuration settings for the web app."""
     for key, value in settings.items():
         cfg.setn('webapp', key, value=value)
+
+
+@plugin.register
+def play_spotify_track(track_uri: str):
+    """Play a Spotify track given its URI"""
+    jukebox.components.spotify.play_spotify_track(track_uri)
+
+
+@plugin.register
+def pause_spotify_playback():
+    """Pause Spotify playback"""
+    jukebox.components.spotify.pause_spotify_playback()
+
+
+@plugin.register
+def resume_spotify_playback():
+    """Resume Spotify playback"""
+    jukebox.components.spotify.resume_spotify_playback()

--- a/src/jukebox/components/mqtt/__init__.py
+++ b/src/jukebox/components/mqtt/__init__.py
@@ -177,6 +177,12 @@ class MQTT(threading.Thread):
                 self._send_volume(payload)
             elif topic == "playerstatus":
                 self._send_player_state(payload)
+            elif topic == "spotify.play":
+                self._send_throttled("spotify/play", payload)
+            elif topic == "spotify.pause":
+                self._send_throttled("spotify/pause", payload)
+            elif topic == "spotify.resume":
+                self._send_throttled("spotify/resume", payload)
         logger.info("Exiting MQTT Thread")
 
     def stop(self):

--- a/src/jukebox/components/player/__init__.py
+++ b/src/jukebox/components/player/__init__.py
@@ -2,6 +2,7 @@ import os
 import re
 import logging
 import jukebox.cfghandler
+import jukebox.components.spotify  # P29c0
 from typing import Optional
 
 
@@ -53,3 +54,18 @@ def get_music_library_path():
     if _MUSIC_LIBRARY_PATH is None:
         _MUSIC_LIBRARY_PATH = MusicLibPath()
     return _MUSIC_LIBRARY_PATH.music_library_path
+
+
+def play_spotify_track(track_uri: str):
+    """Play a Spotify track given its URI"""
+    jukebox.components.spotify.play_spotify_track(track_uri)
+
+
+def pause_spotify_playback():
+    """Pause Spotify playback"""
+    jukebox.components.spotify.pause_spotify_playback()
+
+
+def resume_spotify_playback():
+    """Resume Spotify playback"""
+    jukebox.components.spotify.resume_spotify_playback()

--- a/src/jukebox/components/spotify/__init__.py
+++ b/src/jukebox/components/spotify/__init__.py
@@ -1,0 +1,47 @@
+import logging
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+import jukebox.plugs as plugin
+
+logger = logging.getLogger('jb.spotify')
+
+SPOTIPY_CLIENT_ID = 'your_spotify_client_id'
+SPOTIPY_CLIENT_SECRET = 'your_spotify_client_secret'
+SPOTIPY_REDIRECT_URI = 'your_spotify_redirect_uri'
+
+scope = 'user-read-playback-state,user-modify-playback-state,user-read-currently-playing'
+
+sp = spotipy.Spotify(auth_manager=SpotifyOAuth(client_id=SPOTIPY_CLIENT_ID,
+                                               client_secret=SPOTIPY_CLIENT_SECRET,
+                                               redirect_uri=SPOTIPY_REDIRECT_URI,
+                                               scope=scope))
+
+
+@plugin.register
+def play_spotify_track(track_uri: str):
+    """Play a Spotify track given its URI"""
+    try:
+        sp.start_playback(uris=[track_uri])
+        logger.info(f"Playing Spotify track: {track_uri}")
+    except Exception as e:
+        logger.error(f"Failed to play Spotify track: {e}")
+
+
+@plugin.register
+def pause_spotify_playback():
+    """Pause Spotify playback"""
+    try:
+        sp.pause_playback()
+        logger.info("Paused Spotify playback")
+    except Exception as e:
+        logger.error(f"Failed to pause Spotify playback: {e}")
+
+
+@plugin.register
+def resume_spotify_playback():
+    """Resume Spotify playback"""
+    try:
+        sp.start_playback()
+        logger.info("Resumed Spotify playback")
+    except Exception as e:
+        logger.error(f"Failed to resume Spotify playback: {e}")

--- a/src/jukebox/components/spotify/__init__.py
+++ b/src/jukebox/components/spotify/__init__.py
@@ -2,12 +2,14 @@ import logging
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 import jukebox.plugs as plugin
+import jukebox.cfghandler
 
 logger = logging.getLogger('jb.spotify')
+cfg = jukebox.cfghandler.get_handler('jukebox')
 
-SPOTIPY_CLIENT_ID = 'your_spotify_client_id'
-SPOTIPY_CLIENT_SECRET = 'your_spotify_client_secret'
-SPOTIPY_REDIRECT_URI = 'your_spotify_redirect_uri'
+SPOTIPY_CLIENT_ID = cfg.get('spotify', 'client_id')
+SPOTIPY_CLIENT_SECRET = cfg.get('spotify', 'client_secret')
+SPOTIPY_REDIRECT_URI = cfg.get('spotify', 'redirect_uri')
 
 scope = 'user-read-playback-state,user-modify-playback-state,user-read-currently-playing'
 
@@ -45,3 +47,13 @@ def resume_spotify_playback():
         logger.info("Resumed Spotify playback")
     except Exception as e:
         logger.error(f"Failed to resume Spotify playback: {e}")
+
+
+def initialize():
+    """Initialize the Spotify module"""
+    global sp
+    sp = spotipy.Spotify(auth_manager=SpotifyOAuth(client_id=SPOTIPY_CLIENT_ID,
+                                                   client_secret=SPOTIPY_CLIENT_SECRET,
+                                                   redirect_uri=SPOTIPY_REDIRECT_URI,
+                                                   scope=scope))
+    logger.info("Spotify module initialized")

--- a/src/jukebox/run_jukebox.py
+++ b/src/jukebox/run_jukebox.py
@@ -17,6 +17,7 @@ import logging
 import logging.config
 import jukebox.daemon
 import misc.loggingext
+import jukebox.components.spotify  # P811e
 
 
 def main():
@@ -61,6 +62,7 @@ def main():
         logger.warning(f"script_path : '{script_path}'")
     myjukebox = jukebox.daemon.get_jukebox_daemon(args.conf.name, args.artifacts)
     myjukebox.run()
+    jukebox.components.spotify.initialize()  # P3525
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add Spotify integration to version 3 of the application to enable playing Spotify streams.

* **New Spotify Module**
  - Add `src/jukebox/components/spotify/__init__.py` to handle Spotify integration.
  - Implement functions to authenticate with Spotify API and play, pause, and resume Spotify tracks.

* **Main Application**
  - Update `src/jukebox/run_jukebox.py` to import and initialize the Spotify module.

* **Player Component**
  - Update `src/jukebox/components/player/__init__.py` to include Spotify as a playable source.
  - Implement functions to play, pause, and resume Spotify tracks.

* **Miscellaneous Component**
  - Update `src/jukebox/components/misc.py` to add Spotify commands to the plugin registry.

* **MQTT Component**
  - Update `src/jukebox/components/mqtt/__init__.py` to add Spotify commands to the MQTT command handler.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josbol/RPi-Jukebox-RFID/pull/1?shareId=847f0b52-1b50-4efc-9c32-db81a87980fb).